### PR TITLE
Fix origin for complex recipients

### DIFF
--- a/tkmail/address.py
+++ b/tkmail/address.py
@@ -72,38 +72,36 @@ def get_admin_emails():
     return email_addresses
 
 
-def translate_recipient(year, name, list_ids=False):
+def translate_recipient(year, name):
     """Translate recipient `name` in GF year `year`.
 
     >>> translate_recipient(2010, "K3FORM")
-    ["mathiasrav@gmail.com"]
+    [("mathiasrav@...", "BESTFU2013")]
 
     >>> translate_recipient(2010, "GFORM14")
-    ["mathiasrav@gmail.com"]
+    [("mathiasrav@...", "BESTFU2013")]
 
     >>> translate_recipient(2010, "BEST2013")
-    ["mathiasrav@gmail.com", ...]
+    [("mathiasrav@...", "BESTFU2013"), ...]
 
     >>> translate_recipient(2006, 'FUAA')
-    ['sidse...']
+    [('sidse...', "BESTFU2006")]
 
     >>> translate_recipient(2011, 'FUIØ')
-    ['...@post.au.dk']
+    [('...@post.au.dk', "BESTFU2011")]
 
     >>> translate_recipient(2011, 'FUIOE')
-    ['...@post.au.dk']
+    [('...@post.au.dk', "BESTFU2011")]
     """
 
     name = name.replace('$', 'S')  # KA$$ -> KASS hack
     db = tkmail.database.Database()
-    recipient_ids, origin = parse_recipient(name.upper(), db, year)
-    assert isinstance(recipient_ids, list) and isinstance(origin, list)
-    assert len(recipient_ids) == len(origin)
+    recipients = parse_recipient(name.upper(), db, year)
+    recipient_ids = [recipient_id for recipient_id, origin in recipients]
     email_addresses = db.get_email_addresses(recipient_ids)
-    if list_ids:
-        return email_addresses, dict(zip(email_addresses, origin))
-    else:
-        return email_addresses
+    return [
+        (email_addresses[recipient_id], origin) for recipient_id, origin in recipients
+    ]
 
 
 def parse_recipient(recipient, db, current_period):
@@ -140,7 +138,7 @@ def parse_recipient(recipient, db, current_period):
     recipient_ids = sorted(recipient_ids)
     if not recipient_ids:
         raise InvalidRecipient(recipient)
-    return recipient_ids, [origin[r] for r in recipient_ids]
+    return [(r, origin[r]) for r in recipient_ids]
 
 
 def parse_alias_group(alias, db, current_period):

--- a/tkmail/database.py
+++ b/tkmail/database.py
@@ -29,12 +29,12 @@ class Database(object):
 
     def get_email_addresses(self, id_list):
         id_string = ','.join(str(each) for each in id_list)
-        return self._fetchall("""
-            SELECT `email` FROM `idm_profile`
+        return dict(self._fetchall("""
+            SELECT `id`, `email` FROM `idm_profile`
             WHERE `id` IN (%s)
             AND `allow_direct_email` = TRUE
             AND `email` != ""
-            """, id_string, column=0)
+            """, id_string))
 
     def get_admin_emails(self):
         return self._fetchall("""

--- a/tkmail/server.py
+++ b/tkmail/server.py
@@ -288,15 +288,18 @@ class TKForwarder(SMTPForwarder, MailholeRelayMixin):
 
     def translate_recipient(self, rcptto):
         name, domain = rcptto.split('@')
-        recipients, origin = tkmail.address.translate_recipient(
-            self.year, name, list_ids=True)
+        recipients = tkmail.address.translate_recipient(self.year, name)
         if not recipients:
             logger.info("%s resolved to the empty list", name)
             raise InvalidRecipient(rcptto)
-        recipients.sort(key=lambda r: origin[r])
-        group_iter = itertools.groupby(recipients, key=lambda r: origin[r])
-        groups = [RecipientGroup(origin=o, recipients=frozenset(group))
-                  for o, group in group_iter]
+        recipients.sort(key=lambda r: r[1])
+        group_iter = itertools.groupby(recipients, key=lambda r: r[1])
+        groups = []
+        for origin, group in group_iter:
+            email_addresses = [email_address for email_address, origin in group]
+            groups.append(
+                RecipientGroup(origin=origin, recipients=frozenset(email_addresses))
+            )
         return groups
 
     def get_group_recipients(self, group):


### PR DESCRIPTION
Because Database.get_email_recipients() would not return email addresses
in the same order as the input list of ids, the origins would get mixed
up for a query like KET+JUNTA, resulting in members of JUNTA receiving
emails with List-Id: KET.