### PR TITLE
Change RFC2369 mailto headers to point at admin@ rather then the sender

### DIFF
--- a/tkmail/headers.py
+++ b/tkmail/headers.py
@@ -1,8 +1,9 @@
 def get_extra_headers(sender, list_name, is_group, skip=()):
+    list_requests = 'admin@TAAGEKAMMERET.dk'
     list_id = '%s.TAAGEKAMMERET.dk' % list_name
-    unsub = '<mailto:%s?subject=unsubscribe%%20%s>' % (sender, list_name)
-    help = '<mailto:%s?subject=list-help>' % (sender,)
-    sub = '<mailto:%s?subject=subscribe%%20%s>' % (sender, list_name)
+    unsub = '<mailto:%s?subject=unsubscribe%%20%s>' % (list_requests, list_name)
+    help = '<mailto:%s?subject=list-help>' % (list_requests,)
+    sub = '<mailto:%s?subject=subscribe%%20%s>' % (list_requests, list_name)
     headers = [
         ('Sender', sender),
         ('List-Name', list_name),


### PR DESCRIPTION
Previously, List-Unsubscribe, List-Help and List-Subscribe headers would contain a mailto link to the sender of the email. Since most people who posts to the mailing lists are not involved in maintaining the lists themselves, these emails should rather go to the admin team.

This commit makes headers from custom mailing lists consistent with how the Hængerliste headers look
https://github.com/TK-IT/web/blob/2bd2aa1e7ca176e873f51c90383aaff87fcf4103/tkweb/apps/mailinglist/views.py#L70

Note: The changes are untested.